### PR TITLE
Add hello world custom extern function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ test-driver
 tests/test_*
 !tests/test_*.cpp
 !tests/testdata/*.pcap
+!externs/Makefile
 *.log
 *.trs
 config.guess

--- a/externs/Makefile
+++ b/externs/Makefile
@@ -1,4 +1,4 @@
-LIBS = hello_world.so
+LIBS = hello_world.so ipfix.so
 
 CXX = g++
 CXXFLAGS = -Wall -Wextra -g -O2 -fPIC

--- a/externs/Makefile
+++ b/externs/Makefile
@@ -1,0 +1,15 @@
+LIBS = hello_world.so
+
+CXX = g++
+CXXFLAGS = -Wall -Wextra -g -O2 -fPIC
+LDFLAGS = -shared
+
+.PHONY: all clean
+
+all: $(LIBS)
+
+%.so: %.cpp
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $<
+
+clean:
+	rm -f $(LIBS)

--- a/externs/hello_world.cpp
+++ b/externs/hello_world.cpp
@@ -1,0 +1,24 @@
+/* Copyright 2022 P4lang Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bm/bm_sim/extern.h>
+
+// Hello World extern function
+void hello_world(){
+	std::cout << "IPFIX EXTERN: Hello World" << std::endl;
+}
+BM_REGISTER_EXTERN_FUNCTION(hello_world);
+
+

--- a/externs/hello_world.cpp
+++ b/externs/hello_world.cpp
@@ -16,9 +16,5 @@
 #include <bm/bm_sim/extern.h>
 
 // Hello World extern function
-void hello_world(){
-	std::cout << "IPFIX EXTERN: Hello World" << std::endl;
-}
+void hello_world() { std::cout << "IPFIX EXTERN: Hello World" << std::endl; }
 BM_REGISTER_EXTERN_FUNCTION(hello_world);
-
-

--- a/externs/ipfix.cpp
+++ b/externs/ipfix.cpp
@@ -19,30 +19,31 @@
 #include <bm/bm_sim/data.h>
 #include <bm/bm_sim/extern.h>
 
-
-struct CacheEntry
-{
-    bm::Data indicatorValue;
-    long numPackets;
+struct CacheEntry {
+  bm::Data indicatorValue;
+  long numPackets;
 };
-
 
 std::map<bm::Data, CacheEntry> cache;
 
 // Add PEI value to flow cache entry
-void add_flow_data(const bm::Data & flowLabel, const bm::Data & peiVal) {
-	auto it = cache.find((flowLabel));
+void add_flow_data(const bm::Data &flowLabel, const bm::Data &peiVal) {
+  auto it = cache.find((flowLabel));
   if (it != cache.end()) {
-		cache[flowLabel].indicatorValue.add(cache[flowLabel].indicatorValue, peiVal);
-		cache[flowLabel].numPackets++;
+    cache[flowLabel].indicatorValue.add(cache[flowLabel].indicatorValue,
+                                        peiVal);
+    cache[flowLabel].numPackets++;
   } else {
-		cache[flowLabel].indicatorValue = peiVal;
-		cache[flowLabel].numPackets = 1;
+    cache[flowLabel].indicatorValue = peiVal;
+    cache[flowLabel].numPackets = 1;
   }
 
-	// Iterate over the map and print each key-value pair
-  for (const auto& pair : cache) {
-        std::cout << "IPFIX EXTERN: Key: 0x" << std::hex << pair.first << ", Value: Indicator Value = 0x" << pair.second.indicatorValue << " / Number of Packets = 0x" << pair.second.numPackets << std::endl;
-    }
+  // Iterate over the map and print each key-value pair
+  for (const auto &pair : cache) {
+    std::cout << "IPFIX EXTERN: Key: 0x" << std::hex << pair.first
+              << ", Value: Indicator Value = 0x" << pair.second.indicatorValue
+              << " / Number of Packets = 0x" << pair.second.numPackets
+              << std::endl;
+  }
 }
 BM_REGISTER_EXTERN_FUNCTION(add_flow_data, const bm::Data &, const bm::Data &);

--- a/externs/ipfix.cpp
+++ b/externs/ipfix.cpp
@@ -1,0 +1,48 @@
+/* Copyright 2022 P4lang Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include <map>
+
+#include <bm/bm_sim/data.h>
+#include <bm/bm_sim/extern.h>
+
+
+struct CacheEntry
+{
+    bm::Data indicatorValue;
+    long numPackets;
+};
+
+
+std::map<bm::Data, CacheEntry> cache;
+
+// Add PEI value to flow cache entry
+void add_flow_data(const bm::Data & flowLabel, const bm::Data & peiVal) {
+	auto it = cache.find((flowLabel));
+  if (it != cache.end()) {
+		cache[flowLabel].indicatorValue.add(cache[flowLabel].indicatorValue, peiVal);
+		cache[flowLabel].numPackets++;
+  } else {
+		cache[flowLabel].indicatorValue = peiVal;
+		cache[flowLabel].numPackets = 1;
+  }
+
+	// Iterate over the map and print each key-value pair
+  for (const auto& pair : cache) {
+        std::cout << "IPFIX EXTERN: Key: 0x" << std::hex << pair.first << ", Value: Indicator Value = 0x" << pair.second.indicatorValue << " / Number of Packets = 0x" << pair.second.numPackets << std::endl;
+    }
+}
+BM_REGISTER_EXTERN_FUNCTION(add_flow_data, const bm::Data &, const bm::Data &);


### PR DESCRIPTION
I added a new top level directory containing generic extern libraries.

The extern libraries can be built using the Makefile.
The resulting **.so** files can be used in a BMv2 switch by specifying the path to the so file in the --load-modules command line option.