### PR TITLE
Implement ipfix raw export

### DIFF
--- a/externs/Makefile
+++ b/externs/Makefile
@@ -1,6 +1,6 @@
 TARGET = ipfix
 SRCDIR = src/$(TARGET)
-SOURCES= $(wildcard */*/*.cpp)
+SOURCES= $(wildcard */*/*.cpp) $(wildcard */*/*.h)
 OBJDIR = obj
 CXX = g++
 CXXFLAGS = -Wall -Wextra -g -O2 -fPIC

--- a/externs/src/ipfix/cache.cpp
+++ b/externs/src/ipfix/cache.cpp
@@ -20,10 +20,12 @@
 
 #include "ipfix.h"
 
-bool bg_threads_started = false;
-std::map<uint32_t, FlowRecordCache *> id_cache_map;
-std::mutex id_cache_map_mutex;
+std::mutex cache_index_mutex;
+std::mutex raw_record_cache_mutex;
+FlowRecordCacheIndex cache_index;
+RawRecordCache raw_record_cache;
 uint32_t observation_domain_id;
+bool bg_threads_started = false;
 
 uint32_t GetObservationDomainID() { return observation_domain_id; }
 
@@ -48,20 +50,35 @@ void InitFlowRecord(FlowRecord &dst_record, const bm::Data &flow_label_ipv6,
   dst_record.flow_end_milliseconds = dst_record.flow_start_milliseconds;
 }
 
-void UpdateFlowRecordCache(const bm::Data &flow_key, FlowRecord &record) {
-  std::lock_guard<std::mutex> guard(id_cache_map_mutex);
+FlowRecordCache* GetFlowRecordCache(uint32_t indicator_id) {
+  std::lock_guard<std::mutex> guard(cache_index_mutex);
   FlowRecordCache *cache;
-  auto i = id_cache_map.find((record.efficiency_indicator_id));
+  auto i = cache_index.find((indicator_id));
   // The cache for the specific indicator ID does not exist
-  if (i == id_cache_map.end()) {
+  if (i == cache_index.end()) {
     cache = new FlowRecordCache; // allocate memory on the heap for new cache
-    id_cache_map[record.efficiency_indicator_id] = cache;
+    cache_index[indicator_id] = cache;
   } else {
-    cache = id_cache_map[record.efficiency_indicator_id];
+    cache = cache_index[indicator_id];
   }
-  auto j = cache->find(flow_key);
-  // There is no entry for the specific flow
-  if (j == cache->end()) {
+  return cache;
+}
+
+
+bool IsNewFlow(FlowRecordCache *cache, const bm::Data &flow_key) {
+  std::lock_guard<std::mutex> guard(cache_index_mutex);
+  auto i = cache->find(flow_key);
+  if (i == cache->end()) {
+    return true;
+  }
+  return false;
+}
+
+void ProcessFlowRecord(FlowRecordCache *cache, const bm::Data &flow_key,
+                       FlowRecord &record) {
+  std::lock_guard<std::mutex> guard(cache_index_mutex);
+  auto i = cache->find(flow_key);
+  if (i == cache->end()) {
     cache->insert(std::make_pair(flow_key, record));
   } else {
     cache->at(flow_key).efficiency_indicator_value +=
@@ -77,7 +94,7 @@ void DiscoverExpiredFlowRecords(FlowRecordCache *cache,
   for (auto i = cache->begin(); i != cache->end(); ++i) {
     auto record = i->second;
     if (TimeSinceEpochMillisec() - record.flow_end_milliseconds >
-        FLOW_MAX_IDLE_TIME) {
+        FLOW_EXPORT_RECORD_MAX_IDLE_TIME) {
       std::cout
           << "IPFIX EXPORT: Found expired record - WRITING IN EXPIRED MAP:"
           << std::endl;
@@ -92,8 +109,8 @@ void DeleteFlowRecords(FlowRecordCache *cache, FlowRecordCache &records) {
     auto record = i->second;
     std::cout << "IPFIX EXPORT: Deleting record:" << std::endl;
     std::cout << record << std::endl;
-    delete i->second.source_ipv6_address;
-    delete i->second.destination_ipv6_address;
+    delete[] i->second.source_ipv6_address;
+    delete[] i->second.destination_ipv6_address;
     cache->erase(i->first);
   }
 }
@@ -102,8 +119,8 @@ void RemoveEmptyCaches(std::set<uint32_t> empty_cache_keys) {
   for (auto key : empty_cache_keys) {
     std::cout << "IPFIX EXPORT: Cache with indicator ID 0x" << std::hex << key
               << " is empty - DELETING CACHE" << std::endl;
-    FlowRecordCache *cache = id_cache_map.at(key);
-    id_cache_map.erase(key);
+    FlowRecordCache *cache = cache_index.at(key);
+    cache_index.erase(key);
     delete cache;
   }
 }
@@ -111,51 +128,90 @@ void RemoveEmptyCaches(std::set<uint32_t> empty_cache_keys) {
 void ManageFlowRecordCache() {
   std::cout << "IPFIX EXPORT: Flow record cache mangager started" << std::endl;
   while (true) {
+    sleep(5);
+    std::lock_guard<std::mutex> guard(cache_index_mutex);
     FlowRecordCache expired_records;
     std::set<uint32_t> empty_cache_keys;
     // Iterate over all keys and corresponding values
-    for (auto i = id_cache_map.begin(); i != id_cache_map.end(); i++) {
-      std::lock_guard<std::mutex> guard(id_cache_map_mutex);
+    for (auto i = cache_index.begin();
+         i != cache_index.end(); i++) {
       DiscoverExpiredFlowRecords(i->second, expired_records);
-      ExportFlows(expired_records);
+      ExportFlowRecords(expired_records);
       DeleteFlowRecords(i->second, expired_records);
       if (i->second->empty()) {
         empty_cache_keys.insert(i->first);
       }
     }
     RemoveEmptyCaches(empty_cache_keys);
+  }
+}
+
+RawRecord *GetRawRecord(const bm::Data raw_ipv6_header) {
+  return reinterpret_cast<RawRecord *>(
+      raw_ipv6_header.get_bytes(RAW_EXPORT_IPV6_HEADER_SIZE));
+}
+
+void InsertRawRecord(RawRecord *record) {
+  std::lock_guard<std::mutex> guard(raw_record_cache_mutex);
+  raw_record_cache.push_back(record);
+}
+
+void DeleteRawRecords() {
+  for (RawRecord *r : raw_record_cache) {
+    delete[] r;
+  }
+  raw_record_cache.clear();
+}
+
+void ManageRawRecordCache() {
+  std::cout << "IPFIX EXPORT: Raw record cache mangager started" << std::endl;
+  while (true) {
     sleep(5);
+    std::lock_guard<std::mutex> guard(raw_record_cache_mutex);
+    ExportRawRecords(raw_record_cache);
+    DeleteRawRecords();
   }
 }
 
 //! Extern function called by the dataplane
-void ProcessPacketFlowData(const bm::Data &node_id, const bm::Data &flow_key,
-                           const bm::Data &flow_label_ipv6,
-                           const bm::Data &source_ipv6_address,
-                           const bm::Data &destination_ipv6_address,
-                           const bm::Data &source_transport_port,
-                           const bm::Data &destination_transport_port,
-                           const bm::Data &efficiency_indicator_id,
-                           const bm::Data &efficiency_indicator_value) {
+void ProcessEfficiencyIndicatorMetadata(
+    const bm::Data &node_id, const bm::Data &flow_key,
+    const bm::Data &flow_label_ipv6, const bm::Data &source_ipv6_address,
+    const bm::Data &destination_ipv6_address,
+    const bm::Data &source_transport_port,
+    const bm::Data &destination_transport_port,
+    const bm::Data &efficiency_indicator_id,
+    const bm::Data &efficiency_indicator_value,
+    const bm::Data &raw_ipv6_header) {
   FlowRecord record;
   InitFlowRecord(record, flow_label_ipv6, source_ipv6_address,
                  destination_ipv6_address, source_transport_port,
                  destination_transport_port, efficiency_indicator_id,
                  efficiency_indicator_value);
 
-  UpdateFlowRecordCache(flow_key, record);
+  FlowRecordCache *cache = GetFlowRecordCache(record.efficiency_indicator_id);
+
+  if (IsNewFlow(cache, flow_key)) {
+    RawRecord *record = GetRawRecord(raw_ipv6_header);
+    InsertRawRecord(record);
+  }
+
+  ProcessFlowRecord(cache, flow_key, record);
 
   if (!bg_threads_started) {
     observation_domain_id = node_id.get_int();
     bg_threads_started = true;
-    std::thread cache_manager(ManageFlowRecordCache);
+    std::thread flow_export_cache_manager(ManageFlowRecordCache);
+    std::thread raw_export_cache_manager(ManageRawRecordCache);
     std::thread template_exporter(ExportTemplates);
-    cache_manager.detach();
+    flow_export_cache_manager.detach();
+    raw_export_cache_manager.detach();
     template_exporter.detach();
   }
 }
 
-BM_REGISTER_EXTERN_FUNCTION(ProcessPacketFlowData, const bm::Data &,
+BM_REGISTER_EXTERN_FUNCTION(ProcessEfficiencyIndicatorMetadata,
+                            const bm::Data &, const bm::Data &,
                             const bm::Data &, const bm::Data &,
                             const bm::Data &, const bm::Data &,
                             const bm::Data &, const bm::Data &,

--- a/externs/src/ipfix/export.cpp
+++ b/externs/src/ipfix/export.cpp
@@ -3,10 +3,8 @@
 #include <tins/tins.h>
 
 // Declare mutex for ipfix sequence number
-std::mutex seq_num_mutex;
 
 void ExportFlowRecords(FlowRecordCache &records) {
-  std::lock_guard<std::mutex> guard(seq_num_mutex);
   if (records.size() == 0) {
     return;
   }
@@ -19,7 +17,6 @@ void ExportFlowRecords(FlowRecordCache &records) {
 }
 
 void ExportRawRecords(RawRecordCache &records) {
-  std::lock_guard<std::mutex> guard(seq_num_mutex);
   if (records.size() == 0) {
     return;
   }
@@ -58,7 +55,6 @@ void ExportTemplates() {
   GenerateTemplateMessagePayloads(ts, template_messages);
   while (true) {
     sleep(IPFIX_TEMPLATE_TRANSMISSION_INTERVAL);
-    std::lock_guard<std::mutex> guard(seq_num_mutex);
     for (auto m : template_messages) {
       InitializeMessageHeader(std::get<uint8_t *>(m), std::get<size_t>(m));
       SendMessage(std::get<uint8_t *>(m), std::get<size_t>(m));

--- a/externs/src/ipfix/export.cpp
+++ b/externs/src/ipfix/export.cpp
@@ -1,41 +1,21 @@
+#include "ipfix.h"
 #include <tins/ip.h>
 #include <tins/tins.h>
 
-#include "ipfix.h"
-
-using namespace Tins;
-
 // Declare mutex for ipfix sequence number
 std::mutex seq_num_mutex;
-uint32_t seq_num = 1;
-
-void SendMessage(uint8_t *payload, size_t size) {
-  NetworkInterface iface = NetworkInterface::default_interface();
-  NetworkInterface::Info info = iface.addresses();
-  IP packet = IP(IPFIX_COLLECTOR_IP, info.ip_addr) / UDP(4739, 43700) /
-              RawPDU(payload, size);
-  PacketSender sender;
-  sender.send(packet, iface);
-}
 
 void ExportFlowRecords(FlowRecordCache &records) {
   std::lock_guard<std::mutex> guard(seq_num_mutex);
+  if (records.size() == 0) {
+    return;
+  }
   for (auto i = records.begin(); i != records.end(); ++i) {
     auto record = i->second;
     std::cout << "IPFIX EXPORT: Exporting record:" << std::endl;
     std::cout << record << std::endl;
   }
-
-  if (records.size() == 0) {
-    return;
-  }
-  size_t size = GetMessageSize(records);
-  // TODO: Handle case size > MTU
-  uint8_t *payload = GetPayload(records, size);
-  InitializeMessageHeader(payload, size);
-  SendMessage(payload, size);
-  seq_num += records.size();
-  delete[] payload;
+  TrySendRecords(records);
 }
 
 void ExportRawRecords(RawRecordCache &records) {
@@ -43,17 +23,9 @@ void ExportRawRecords(RawRecordCache &records) {
   if (records.size() == 0) {
     return;
   }
-
   std::cout << "IPFIX EXPORT: Exporting " << records.size()
             << " raw record(s):" << std::endl;
-
-  size_t size = GetMessageSize(records);
-  // TODO: Handle case size > MTU
-  uint8_t *payload = GetPayload(records, size);
-  InitializeMessageHeader(payload, size);
-  SendMessage(payload, size);
-  seq_num += records.size();
-  delete[] payload;
+  TrySendRecords(records);
 }
 
 // Send template records in a given intervall
@@ -82,135 +54,14 @@ void ExportTemplates() {
   // Initialize template set map
   TemplateSets ts{{IPFIX_FLOW_RECORD_SET_ID, flow_export_template_records},
                   {IPFIX_RAW_IP_HEADER_SET_ID, raw_export_template_records}};
-  size_t size = GetMessageSize(ts);
-  // TODO: Handle case size > MTU
-  uint8_t *payload = GetPayload(ts, size);
+  PayloadList template_messages;
+  GenerateTemplateMessagePayloads(ts, template_messages);
   while (true) {
-    InitializeMessageHeader(payload, size);
-    SendMessage(payload, size);
     sleep(IPFIX_TEMPLATE_TRANSMISSION_INTERVAL);
-  }
-}
-
-void InitializeMessageHeader(uint8_t *payload, size_t size) {
-  MessageHeader mh;
-  mh.version_number = IPFIX_VERSION_NUMBER;
-  mh.length = size;
-  mh.export_time = TimeSinceEpochSec();
-  mh.sequence_number = seq_num;
-  mh.observation_domain_id = GetObservationDomainID();
-  hton(mh);
-  std::memcpy(payload, &mh, sizeof(MessageHeader));
-}
-
-uint16_t GetMessageSize(FlowRecordCache &records) {
-  return sizeof(MessageHeader) + sizeof(SetHeader) +
-         records.size() * sizeof(FlowRecordDataSet);
-}
-
-uint16_t GetMessageSize(RawRecordCache &records) {
-  return sizeof(MessageHeader) + sizeof(SetHeader) +
-         records.size() * sizeof(RawRecordDataSet);
-}
-
-uint16_t GetMessageSize(TemplateSets &sets) {
-  uint16_t size = sizeof(MessageHeader) + sizeof(SetHeader);
-  for (auto tmpl = sets.begin(); tmpl != sets.end(); ++tmpl) {
-    size += sizeof(TemplateRecordHeader);
-    size += sizeof(FieldSpecifier) * tmpl->second.size();
-  }
-  return size;
-}
-
-uint8_t *GetPayload(FlowRecordCache &records, size_t size) {
-  uint8_t *payload = new uint8_t[size];
-  uint offset = sizeof(MessageHeader);
-
-  SetHeader sh;
-  sh.set_id = IPFIX_FLOW_RECORD_SET_ID;
-  sh.length = size - sizeof(MessageHeader);
-
-  hton(sh);
-  std::memcpy(&payload[offset], &sh, sizeof(SetHeader));
-  offset += sizeof(SetHeader);
-
-  for (auto r = records.begin(); r != records.end(); ++r) {
-    FlowRecordDataSet ds;
-    ds.flow_label_ipv6 = r->second.flow_label_ipv6;
-    ds.source_transport_port = r->second.source_transport_port;
-    ds.destination_transport_port = r->second.destination_transport_port;
-    ds.efficiency_indicator_id = r->second.efficiency_indicator_id;
-    ds.efficiency_indicator_value = r->second.efficiency_indicator_value;
-    ds.packet_delta_count = r->second.packet_delta_count;
-    ds.flow_start_milliseconds = r->second.flow_start_milliseconds;
-    ds.flow_end_milliseconds = r->second.flow_end_milliseconds;
-    std::memcpy(ds.source_ipv6_address, r->second.source_ipv6_address, 16);
-    std::memcpy(ds.destination_ipv6_address, r->second.destination_ipv6_address,
-                16);
-
-    hton(ds);
-    std::memcpy(&payload[offset], &ds, sizeof(FlowRecordDataSet));
-    offset += sizeof(FlowRecordDataSet);
-  }
-  return payload;
-}
-
-uint8_t *GetPayload(RawRecordCache &records, size_t size) {
-  uint8_t *payload = new uint8_t[size];
-  uint offset = sizeof(MessageHeader);
-
-  SetHeader sh;
-  sh.set_id = IPFIX_RAW_IP_HEADER_SET_ID;
-  sh.length = size - sizeof(MessageHeader);
-
-  hton(sh);
-  std::memcpy(&payload[offset], &sh, sizeof(SetHeader));
-  offset += sizeof(SetHeader);
-
-  for (auto r : records) {
-    RawRecordDataSet ds;
-    ds.ioam_report_flags = 0;
-    // 64 indicates that the packet was forwarded and no further information is
-    // provided. Refer to https://www.iana.org/assignments/ipfix/ipfix.xhtml
-    ds.forwarding_status = 64;
-    ds.section_exported_octets = 0;
-
-    std::memcpy(ds.ip_header_packet_section, r, sizeof(RawRecord));
-
-    hton(ds);
-    std::memcpy(&payload[offset], &ds, sizeof(RawRecordDataSet));
-    offset += sizeof(RawRecordDataSet);
-  }
-  return payload;
-}
-
-uint8_t *GetPayload(TemplateSets &sets, size_t size) {
-  uint8_t *payload = new uint8_t[size];
-  uint offset = sizeof(MessageHeader);
-
-  SetHeader sh;
-  sh.set_id = IPFIX_TEMPLATE_SET_ID;
-  sh.length = size - sizeof(MessageHeader);
-
-  hton(sh);
-  std::memcpy(&payload[offset], &sh, sizeof(SetHeader));
-  offset += sizeof(SetHeader);
-
-  for (auto tmpl = sets.begin(); tmpl != sets.end(); ++tmpl) {
-    // Process template header
-    TemplateRecordHeader th;
-    th.template_id = tmpl->first;
-    th.field_count = tmpl->second.size();
-    hton(th);
-    std::memcpy(&payload[offset], &th, sizeof(TemplateRecordHeader));
-    offset += sizeof(TemplateRecordHeader);
-
-    // Process template records
-    for (FieldSpecifier r : tmpl->second) {
-      hton(r);
-      std::memcpy(&payload[offset], &r, sizeof(FieldSpecifier));
-      offset += sizeof(FieldSpecifier);
+    std::lock_guard<std::mutex> guard(seq_num_mutex);
+    for (auto m : template_messages) {
+      InitializeMessageHeader(std::get<uint8_t *>(m), std::get<size_t>(m));
+      SendMessage(std::get<uint8_t *>(m), std::get<size_t>(m));
     }
   }
-  return payload;
 }

--- a/externs/src/ipfix/export_utils.cpp
+++ b/externs/src/ipfix/export_utils.cpp
@@ -1,0 +1,269 @@
+#include <tins/ip.h>
+#include <tins/tins.h>
+
+#include "ipfix.h"
+
+using namespace Tins;
+
+uint32_t seq_num = 1;
+
+void TrySendRecords(FlowRecordCache &records) {
+  std::cout << "IPFIX EXPORT: Trying to send flow records" << std::endl;
+  size_t size = GetMessageSize(records);
+  uint8_t *payload = GetPayload(records, size);
+  InitializeMessageHeader(payload, size);
+  try {
+    SendMessage(payload, size);
+    seq_num += records.size();
+    delete[] payload;
+  } catch (const Tins::socket_write_error &e) {
+    delete[] payload;
+    if (std::string(e.what()) == "Message too long") {
+      HandleMessageTooLong(records);
+    } else {
+      throw;
+    }
+  }
+}
+
+void TrySendRecords(RawRecordCache &records) {
+  std::cout << "IPFIX EXPORT: Trying to send raw records" << std::endl;
+  size_t size = GetMessageSize(records);
+  uint8_t *payload = GetPayload(records, size);
+  InitializeMessageHeader(payload, size);
+  try {
+    SendMessage(payload, size);
+    seq_num += records.size();
+    delete[] payload;
+  } catch (const Tins::socket_write_error &e) {
+    delete[] payload;
+    if (std::string(e.what()) == "Message too long") {
+      HandleMessageTooLong(records);
+    } else {
+      throw;
+    }
+  }
+}
+
+void SendMessage(uint8_t *payload, size_t size) {
+  std::cout << "IPFIX EXPORT: Sending IPFIX message" << std::endl;
+  NetworkInterface iface = NetworkInterface::default_interface();
+  NetworkInterface::Info info = iface.addresses();
+  IP packet = IP(IPFIX_COLLECTOR_IP, info.ip_addr) / UDP(4739, 43700) /
+              RawPDU(payload, size);
+  PacketSender sender;
+  sender.send(packet, iface);
+}
+
+void GenerateTemplateMessagePayloads(TemplateSets sets, PayloadList &dst) {
+  std::cout << "IPFIX EXPORT: Getting template messages" << std::endl;
+  size_t size = GetMessageSize(sets);
+  uint8_t *payload = GetPayload(sets, size);
+  InitializeMessageHeader(payload, size);
+  try {
+    SendMessage(payload, size);
+    dst.push_back(std::make_tuple(size, payload));
+  } catch (const Tins::socket_write_error &e) {
+    delete[] payload;
+    if (std::string(e.what()) == "Message too long") {
+      HandleMessageTooLong(sets, dst);
+    } else {
+      throw;
+    }
+  }
+}
+
+void HandleMessageTooLong(FlowRecordCache &records) {
+  std::cout << "Handling message too long error for flow records" << std::endl;
+  FlowRecordCache first_split;
+  FlowRecordCache second_split;
+  SplitRecords(records, first_split, second_split);
+  TrySendRecords(first_split);
+  TrySendRecords(second_split);
+}
+
+void HandleMessageTooLong(RawRecordCache &records) {
+  std::cout << "Handling message too long error for raw records" << std::endl;
+  RawRecordCache first_split;
+  RawRecordCache second_split;
+  SplitRecords(records, first_split, second_split);
+  TrySendRecords(first_split);
+  TrySendRecords(second_split);
+}
+
+void HandleMessageTooLong(TemplateSets &sets, PayloadList &dst) {
+  std::cout << "Handling message too long error for template sets" << std::endl;
+  TemplateSets first_split;
+  TemplateSets second_split;
+  SplitRecords(sets, first_split, second_split);
+  GenerateTemplateMessagePayloads(first_split, dst);
+  GenerateTemplateMessagePayloads(second_split, dst);
+}
+
+void SplitRecords(FlowRecordCache &records, FlowRecordCache &first,
+                  FlowRecordCache &second) {
+  std::cout << "IPFIX EXPORT: Splitting flow records" << std::endl;
+  int counter = 0;
+  int half_size = records.size() / 2;
+  for (auto i = records.begin(); i != records.end(); ++i) {
+    if (counter < half_size) {
+      first.insert(std::make_pair(i->first, i->second));
+    } else {
+      second.insert(std::make_pair(i->first, i->second));
+    }
+    counter++;
+  }
+}
+
+void SplitRecords(TemplateSets &records, TemplateSets &first,
+                  TemplateSets &second) {
+  std::cout << "IPFIX EXPORT: Splitting template sets" << std::endl;
+  int counter = 0;
+  int half_size = records.size() / 2;
+  for (auto i = records.begin(); i != records.end(); ++i) {
+    if (counter < half_size) {
+      first.insert(std::make_pair(i->first, i->second));
+    } else {
+      second.insert(std::make_pair(i->first, i->second));
+    }
+    counter++;
+  }
+}
+
+void SplitRecords(RawRecordCache &records, RawRecordCache &first,
+                  RawRecordCache &second) {
+  std::cout << "IPFIX EXPORT: Splitting raw records" << std::endl;
+  int counter = 0;
+  int half_size = records.size() / 2;
+  for (auto record : records) {
+    if (counter < half_size) {
+      first.push_back(record);
+    } else {
+      second.push_back(record);
+    }
+    counter++;
+  }
+}
+
+void InitializeMessageHeader(uint8_t *payload, size_t size) {
+  MessageHeader mh;
+  mh.version_number = IPFIX_VERSION_NUMBER;
+  mh.length = size;
+  mh.export_time = TimeSinceEpochSec();
+  mh.sequence_number = seq_num;
+  mh.observation_domain_id = GetObservationDomainID();
+  hton(mh);
+  std::memcpy(payload, &mh, sizeof(MessageHeader));
+}
+
+uint16_t GetMessageSize(FlowRecordCache &records) {
+  return sizeof(MessageHeader) + sizeof(SetHeader) +
+         records.size() * sizeof(FlowRecordDataSet);
+}
+
+uint16_t GetMessageSize(RawRecordCache &records) {
+  return sizeof(MessageHeader) + sizeof(SetHeader) +
+         records.size() * sizeof(RawRecordDataSet);
+}
+
+uint16_t GetMessageSize(TemplateSets &sets) {
+  uint16_t size = sizeof(MessageHeader) + sizeof(SetHeader);
+  for (auto tmpl = sets.begin(); tmpl != sets.end(); ++tmpl) {
+    size += sizeof(TemplateRecordHeader);
+    size += sizeof(FieldSpecifier) * tmpl->second.size();
+  }
+  return size;
+}
+
+uint8_t *GetPayload(FlowRecordCache &records, size_t size) {
+  uint8_t *payload = new uint8_t[size];
+  uint offset = sizeof(MessageHeader);
+
+  SetHeader sh;
+  sh.set_id = IPFIX_FLOW_RECORD_SET_ID;
+  sh.length = size - sizeof(MessageHeader);
+
+  hton(sh);
+  std::memcpy(&payload[offset], &sh, sizeof(SetHeader));
+  offset += sizeof(SetHeader);
+
+  for (auto r = records.begin(); r != records.end(); ++r) {
+    FlowRecordDataSet ds;
+    ds.flow_label_ipv6 = r->second.flow_label_ipv6;
+    ds.source_transport_port = r->second.source_transport_port;
+    ds.destination_transport_port = r->second.destination_transport_port;
+    ds.efficiency_indicator_id = r->second.efficiency_indicator_id;
+    ds.efficiency_indicator_value = r->second.efficiency_indicator_value;
+    ds.packet_delta_count = r->second.packet_delta_count;
+    ds.flow_start_milliseconds = r->second.flow_start_milliseconds;
+    ds.flow_end_milliseconds = r->second.flow_end_milliseconds;
+    std::memcpy(ds.source_ipv6_address, r->second.source_ipv6_address, 16);
+    std::memcpy(ds.destination_ipv6_address, r->second.destination_ipv6_address,
+                16);
+
+    hton(ds);
+    std::memcpy(&payload[offset], &ds, sizeof(FlowRecordDataSet));
+    offset += sizeof(FlowRecordDataSet);
+  }
+  return payload;
+}
+
+uint8_t *GetPayload(RawRecordCache &records, size_t size) {
+  uint8_t *payload = new uint8_t[size];
+  uint offset = sizeof(MessageHeader);
+
+  SetHeader sh;
+  sh.set_id = IPFIX_RAW_IP_HEADER_SET_ID;
+  sh.length = size - sizeof(MessageHeader);
+
+  hton(sh);
+  std::memcpy(&payload[offset], &sh, sizeof(SetHeader));
+  offset += sizeof(SetHeader);
+
+  for (auto r : records) {
+    RawRecordDataSet ds;
+    ds.ioam_report_flags = 0;
+    // 64 indicates that the packet was forwarded and no further information is
+    // provided. Refer to https://www.iana.org/assignments/ipfix/ipfix.xhtml
+    ds.forwarding_status = 64;
+    ds.section_exported_octets = 0;
+
+    std::memcpy(ds.ip_header_packet_section, r, sizeof(RawRecord));
+
+    hton(ds);
+    std::memcpy(&payload[offset], &ds, sizeof(RawRecordDataSet));
+    offset += sizeof(RawRecordDataSet);
+  }
+  return payload;
+}
+
+uint8_t *GetPayload(TemplateSets &sets, size_t size) {
+  uint8_t *payload = new uint8_t[size];
+  uint offset = sizeof(MessageHeader);
+
+  SetHeader sh;
+  sh.set_id = IPFIX_TEMPLATE_SET_ID;
+  sh.length = size - sizeof(MessageHeader);
+
+  hton(sh);
+  std::memcpy(&payload[offset], &sh, sizeof(SetHeader));
+  offset += sizeof(SetHeader);
+
+  for (auto tmpl = sets.begin(); tmpl != sets.end(); ++tmpl) {
+    // Process template header
+    TemplateRecordHeader th;
+    th.template_id = tmpl->first;
+    th.field_count = tmpl->second.size();
+    hton(th);
+    std::memcpy(&payload[offset], &th, sizeof(TemplateRecordHeader));
+    offset += sizeof(TemplateRecordHeader);
+
+    // Process template records
+    for (FieldSpecifier r : tmpl->second) {
+      hton(r);
+      std::memcpy(&payload[offset], &r, sizeof(FieldSpecifier));
+      offset += sizeof(FieldSpecifier);
+    }
+  }
+  return payload;
+}

--- a/externs/src/ipfix/export_utils.cpp
+++ b/externs/src/ipfix/export_utils.cpp
@@ -6,8 +6,10 @@
 using namespace Tins;
 
 uint32_t seq_num = 1;
+std::mutex seq_num_mutex;
 
 void TrySendRecords(FlowRecordCache &records) {
+  std::lock_guard<std::mutex> guard(seq_num_mutex);
   std::cout << "IPFIX EXPORT: Trying to send flow records" << std::endl;
   size_t size = GetMessageSize(records);
   uint8_t *payload = GetPayload(records, size);
@@ -22,6 +24,7 @@ void TrySendRecords(FlowRecordCache &records) {
 }
 
 void TrySendRecords(RawRecordCache &records) {
+  std::lock_guard<std::mutex> guard(seq_num_mutex);
   std::cout << "IPFIX EXPORT: Trying to send raw records" << std::endl;
   size_t size = GetMessageSize(records);
   uint8_t *payload = GetPayload(records, size);
@@ -57,6 +60,7 @@ int SendMessage(uint8_t *payload, size_t size) {
 }
 
 void GenerateTemplateMessagePayloads(TemplateSets sets, PayloadList &dst) {
+  std::lock_guard<std::mutex> guard(seq_num_mutex);
   std::cout << "IPFIX EXPORT: Getting template messages" << std::endl;
   size_t size = GetMessageSize(sets);
   uint8_t *payload = GetPayload(sets, size);

--- a/externs/src/ipfix/hton.cpp
+++ b/externs/src/ipfix/hton.cpp
@@ -50,3 +50,7 @@ void hton(FlowRecordDataSet &record) {
   record.flow_start_milliseconds = htonll(record.flow_start_milliseconds);
   record.flow_end_milliseconds = htonll(record.flow_end_milliseconds);
 }
+
+void hton(RawRecordDataSet &record) {
+  record.section_exported_octets = htons(record.section_exported_octets);
+}

--- a/externs/src/ipfix/ipfix.h
+++ b/externs/src/ipfix/ipfix.h
@@ -1,15 +1,16 @@
 #include <bm/bm_sim/data.h>
 #include <cstdint>
 
-// Maximum idle time of flows in milliseconds. Used to trigger export and cache
-// cleanup on timeout.
-#define FLOW_MAX_IDLE_TIME 10000
-#define INDICATOR_ID_PEI 0xFF
+// Duration specified in milliseconds
+#define FLOW_EXPORT_RECORD_MAX_IDLE_TIME 10000
+// Size specified in bytes
+#define RAW_EXPORT_IPV6_HEADER_SIZE 96
 #define IPFIX_VERSION_NUMBER 0x000a
 #define IPFIX_COLLECTOR_IP "10.0.2.2"
-// Transmission intervall of IPFIX templates specified in seconds.
+// Duration specifed in seconds
 #define IPFIX_TEMPLATE_TRANSMISSION_INTERVAL 20
 #define IPFIX_FLOW_RECORD_SET_ID 256
+#define IPFIX_RAW_IP_HEADER_SET_ID 257
 #define IPFIX_TEMPLATE_SET_ID 2
 
 // IPFIX message header as specified in section 3.1 in RFC7011.
@@ -79,8 +80,28 @@ struct FlowRecord {
   uint64_t flow_end_milliseconds;
 };
 
-// Flow Record cache maps a flow key on the corresponding FlowRecord.
+// Array data structure that holds IPv6 header raw data as so called raw
+// records.
+typedef unsigned char RawRecord[RAW_EXPORT_IPV6_HEADER_SIZE];
+
+// IPFIX Data Set for IOAM raw export.
+// The packed attribute is set because the memcpy operation is performed on
+// instances of this type.
+struct RawRecordDataSet {
+  uint8_t ioam_report_flags;
+  uint8_t forwarding_status;
+  uint16_t section_exported_octets;
+  RawRecord ip_header_packet_section;
+} __attribute__((packed));
+
+// FlowRecordCache maps a flow key on the corresponding FlowRecord.
 typedef std::map<bm::Data, FlowRecord> FlowRecordCache;
+// FlowRecordCacheIndex maps a indicator ID on the corresponding
+// FlowRecordCache.
+typedef std::map<uint32_t, FlowRecordCache *> FlowRecordCacheIndex;
+// RawRecordCache stores the RawRecords.
+typedef std::list<RawRecord *> RawRecordCache;
+
 // TemplateSets maps the template ID to the list of corresponding field
 // specifiers.
 typedef std::map<uint16_t, std::list<FieldSpecifier>> TemplateSets;
@@ -104,14 +125,26 @@ void InitFlowRecord(FlowRecord &dst_record, const bm::Data &flow_label_ipv6,
                     const bm::Data &efficiency_indicator_id,
                     const bm::Data &efficiency_indicator_value);
 
+// Returns a pointer to the FlowRecordCache holding entries for the given
+// indicator_id. In case there is no active cache for the given indicator_id in
+// the cache_index a new flow record cache is allocated on the heap and inserted
+// into the cache_index.
+FlowRecordCache *GetFlowRecordCache(uint32_t indicator_id);
+
+// Returns a boolean to indicate if the flow with the given flow_key exists in
+// the given cache. In case the flow_key does not exist the flow is considered
+// new and the function returns true, otherwise false.
+bool IsNewFlow(FlowRecordCache *cache, const bm::Data &flow_key);
+
 // Processes a given record by updating the cache entry in the cache with the
 // corresponding efficiency indicator id and matching flow key.
 // In case the cache does not contain an entry with the given flow key,
 // the record is inserted into the cache and associated with the given
 // flow key. Otherwise the matched entry is updated.
 // As the target data structure is used simultaneously by other threads
-// this function acquires a lock with the mutex id_cache_map.
-void ProcessFlowRecord(const bm::Data &flow_key, FlowRecord &record);
+// this function acquires a lock with the mutex cache_index_mutex.
+void ProcessFlowRecord(FlowRecordCache *cache, const bm::Data &flow_key,
+                       FlowRecord &record);
 
 // Discovers expired flow records in the given cache.
 // Expired records are written to the provided expired_records
@@ -119,7 +152,7 @@ void ProcessFlowRecord(const bm::Data &flow_key, FlowRecord &record);
 void DiscoverExpiredFlowRecords(FlowRecordCache *cache,
                                 FlowRecordCache &expired_records);
 
-// Deletes flow the given records from the given cache.
+// Deletes the given flow records from the given cache.
 void DeleteFlowRecords(FlowRecordCache *cache, FlowRecordCache &records);
 
 // Removes the caches for a specific indicator ID from the heap which are empty.
@@ -128,15 +161,37 @@ void DeleteFlowRecords(FlowRecordCache *cache, FlowRecordCache &records);
 void RemoveEmptyCaches(std::set<uint32_t> empty_cache_keys);
 
 // Manages the flow record cache. It is executed as a background task
-// running inside a detached thred. As the target data structure is used
+// running inside a detached thread. As the target data structure is used
 // simultaneously by other threads this function acquires a lock with the
-// mutex id_cache_map. The function never terminates.
+// mutex cache_index_mutex. The function never terminates.
 void ManageFlowRecordCache();
 
-// Processes the packet flow data. The function is called by the data plane as
-// P4 extern function. It obtains all values relevant for the caching and
-// export process. This function is the entry point in the ipfix implementation
-// and starts all related background threads if not already started.
+// This function returns a pointer on a RawRecord given the raw_ipv6_header as
+// bm::Data. The actual RawRecord is allocated on the heap and needs to be
+// deleted explicitely once it is not needed anymore.
+RawRecord *GetRawRecord(const bm::Data raw_ipv6_header);
+
+// Inserts the given RawRecrod into the list holding all raw records.
+// The function acquires a lock on the raw_record_cache as it is used
+// simultaneously.
+void InsertRawRecord(RawRecord *record);
+
+// Deletes (deallocation on the heap) the exported raw records and clears the
+// raw record cache. The function acquires a lock on the raw_record_cache as it
+// is used simultaneously.
+void DeleteRawRecords();
+
+// Manages the raw record cache. It is executed as a background task
+// running inside a detached thread. The function never terminates.
+// The function acquires a lock on the raw_record_cache as it is used
+// simultaneously.
+void ManageRawRecordCache();
+
+// Processes the packet flow and raw data. The function is called by the data
+// plane as P4 extern function. It obtains all values relevant for the caching
+// and export process. This function is the entry point in the ipfix
+// implementation and starts all related background threads if not already
+// started.
 void ProcessPacketFlowData(const bm::Data &node_id, const bm::Data &flow_key,
                            const bm::Data &flow_label_ipv6,
                            const bm::Data &source_ipv6_address,
@@ -152,14 +207,16 @@ void ProcessPacketFlowData(const bm::Data &node_id, const bm::Data &flow_key,
 // the default interface.
 void SendMessage(uint8_t *payload, size_t size);
 
-// Exports the given records.
-// It initializes the payload and hands it over to the SendMessage
-// function for transmission.
-void ExportFlows(FlowRecordCache &records);
+// Exports the given flow records. It initializes the payload and hands it over
+// to the SendMessage function for transmission.
+void ExportFlowRecords(FlowRecordCache &records);
 
-// Exports the templates defined locally.
-// It initializes the payload and hands it over to the SendMessage
-// function for transmission.
+// Exports the given raw records. It initializes the payload and hands it over
+// to the SendMessage function for transmission.
+void ExportRawRecords(RawRecordCache &records);
+
+// Exports the templates defined locally. It initializes the payload and hands
+// it over to the SendMessage function for transmission.
 void ExportTemplates();
 
 // Initializes the first 16 bytes of the payload as the IPFIX message header.
@@ -167,41 +224,63 @@ void InitializeMessageHeader(uint8_t *payload, size_t size);
 
 // Returns the size of the total flow export message, given the records to
 // export.
-uint16_t GetFlowExportMessageSize(FlowRecordCache &records);
+uint16_t GetMessageSize(FlowRecordCache &records);
+
+// Returns the size of the total raw export message, given the records to
+// export.
+uint16_t GetMessageSize(RawRecordCache &records);
 
 // Returns the size of the total template export message, given the templates to
 // export.
-uint16_t GetTemplateExportMessageSize(TemplateSets &sets);
+uint16_t GetMessageSize(TemplateSets &sets);
 
-// Returns the initialized payload in network byte order given the records to
-// export and the size of the payload.
+// Returns the initialized flow record payload in network byte order (big
+// endian) given the records to export and the size of the payload.
 uint8_t *GetPayload(FlowRecordCache &records, size_t size);
 
-// Returns the initialized payload in network byte order given the templates to
-// export and the size of the payload.
+// Returns the initialized raw record payload in network byte order (big endian)
+// given the records to export and the size of the payload.
+uint8_t *GetPayload(RawRecordCache &records, size_t size);
+
+// Returns the initialized template payload in network byte order (big endian)
+// given the templates to export and the size of the payload.
 uint8_t *GetPayload(TemplateSets &sets, size_t size);
 
 // Function Signatures in hton.cpp
 
+// Converts a 64 bit integer from host byte order (little endian) to network
+// byte order (big endian).
+uint64_t htonll(uint64_t x);
+
 // Converts a struct variable from the type MessageHeader from host byte order
-// to network byte order given the reference of the target datastructure.
+// (little endian) to network byte order (big endian) given the reference of the
+// target datastructure.
 void hton(MessageHeader &header);
 
 // Converts a struct variable from the type SetHeader from host byte order
-// to network byte order given the reference of the target datastructure.
+// (little endian) to network byte order (big endian) given the reference of the
+// target datastructure.
 void hton(SetHeader &header);
 
 // Converts a struct variable from the type TemplateRecordHeader from host byte
-// order to network byte order given the reference of the target datastructure.
+// order to network byte order (big endian) given the reference of the target
+// datastructure.
 void hton(TemplateRecordHeader &header);
 
 // Converts a struct variable from the type TemplateRecord from host byte order
-// to network byte order given the reference of the target datastructure.
+// (little endian) to network byte order (big endian) given the reference of the
+// target datastructure.
 void hton(FieldSpecifier &field);
 
 // Converts a struct variable from the type FlowRecordDataSet from host byte
-// order to network byte order given the reference of the target datastructure.
+// order to network byte order (big endian) given the reference of the target
+// datastructure.
 void hton(FlowRecordDataSet &record);
+
+// Converts a struct variable from the type RawRecordDataSet from host byte
+// order to network byte order (big endian) given the reference of the target
+// datastructure.
+void hton(RawRecordDataSet &record);
 
 // Function Signatures in utils.cpp
 

--- a/externs/src/ipfix/ipfix.h
+++ b/externs/src/ipfix/ipfix.h
@@ -8,6 +8,8 @@
 #define FLOW_EXPORT_RECORD_MAX_IDLE_TIME 10000
 // Size specified in bytes
 #define RAW_EXPORT_IPV6_HEADER_SIZE 96
+
+// IPFIX
 #define IPFIX_VERSION_NUMBER 0x000a
 #define IPFIX_COLLECTOR_IP "10.0.2.2"
 // Duration specifed in seconds
@@ -15,6 +17,10 @@
 #define IPFIX_FLOW_RECORD_SET_ID 256
 #define IPFIX_RAW_IP_HEADER_SET_ID 257
 #define IPFIX_TEMPLATE_SET_ID 2
+
+// Errors
+#define ERR_OK 0
+#define ERR_MESSAGE_TOO_LONG 1
 
 // IPFIX message header as specified in section 3.1 in RFC7011.
 // The packed attribute is set because the memcpy operation is performed on
@@ -225,22 +231,24 @@ void ExportTemplates();
 // Function signatures in export_utils.cpp
 
 // Sends a given payload of a given size inside a UDP datagram as RawPDU out of
-// the default interface.
-void SendMessage(uint8_t *payload, size_t size);
+// the default interface. Returns ERR_MESSAGE_TOO_LONG in case of a "Message too
+// long" exception or ERR_OK in case the message was sent succesfully. Any other
+// exception which occured during the sending process is thrown.
+int SendMessage(uint8_t *payload, size_t size);
 
-// Tries to send the given flow records. The function catches the "Message too
-// long" exception and calls the specifc error handler to split up the records
-// in multiple messages.
+// Tries to send the given flow records. In case the "Message too long"
+// exception occurs in the SendMessage function the message is split up into
+// multiple messages until the messages are small enough to be transmitted.
 void TrySendRecords(FlowRecordCache &records);
 
-// Tries to send the given raw records. The function catches the "Message too
-// long" exception and calls the specifc error handler to split up the records
-// in multiple messages.
+// Tries to send the given raw records. In case the "Message too long"
+// exception occurs in the SendMessage function the message is split up into
+// multiple messages until the messages are small enough to be transmitted.
 void TrySendRecords(RawRecordCache &records);
 
 // Generates the static template message payloads given the sets and stores the
 // size and the corresponding payload in the provided list. The function
-// validated that the size of the generated payload is valid and splits up the
+// validates that the size of the generated payload is valid and splits up the
 // sets into multiple messages if required.
 void GenerateTemplateMessagePayloads(TemplateSets sets, PayloadList &dst);
 


### PR DESCRIPTION
Added the functionality for IOAM Raw export according to: https://datatracker.ietf.org/doc/html/draft-spiegel-ippm-ioam-rawexport-07.

The implementation supports the raw IOAM **Fixed Length IP Packet** export.