### PR TITLE
Refactor flow based export

### DIFF
--- a/externs/src/ipfix/cache.cpp
+++ b/externs/src/ipfix/cache.cpp
@@ -152,10 +152,10 @@ void ManageFlowRecordCache() {
   while (true) {
     sleep(5);
     std::lock_guard<std::mutex> guard(cache_index_mutex);
-    FlowRecordCache expired_records;
     std::set<uint32_t> empty_cache_keys;
     // Iterate over all keys and corresponding values
     for (auto i = cache_index.begin(); i != cache_index.end(); i++) {
+      FlowRecordCache expired_records;
       DiscoverExpiredFlowRecords(i->second, expired_records);
       ExportFlowRecords(expired_records);
       DeleteFlowRecords(i->second, expired_records);

--- a/externs/src/ipfix/export.cpp
+++ b/externs/src/ipfix/export.cpp
@@ -37,12 +37,13 @@ void ExportTemplates() {
       FieldSpecifier{.information_element_id = 11, .field_length = 2},
       FieldSpecifier{.information_element_id = 5050, .field_length = 4},
       FieldSpecifier{.information_element_id = 5051, .field_length = 8},
+      FieldSpecifier{.information_element_id = 5052, .field_length = 1},
       FieldSpecifier{.information_element_id = 2, .field_length = 8},
       FieldSpecifier{.information_element_id = 152, .field_length = 8},
       FieldSpecifier{.information_element_id = 153, .field_length = 8},
   };
   std::list<FieldSpecifier> raw_export_template_records = {
-      FieldSpecifier{.information_element_id = 5052, .field_length = 1},
+      FieldSpecifier{.information_element_id = 5053, .field_length = 1},
       FieldSpecifier{.information_element_id = 89, .field_length = 1},
       FieldSpecifier{.information_element_id = 410, .field_length = 2},
       FieldSpecifier{.information_element_id = 313,

--- a/externs/src/ipfix/export_utils.cpp
+++ b/externs/src/ipfix/export_utils.cpp
@@ -195,6 +195,8 @@ uint8_t *GetPayload(FlowRecordCache &records, size_t size) {
     ds.destination_transport_port = r->second.destination_transport_port;
     ds.efficiency_indicator_id = r->second.efficiency_indicator_id;
     ds.efficiency_indicator_value = r->second.efficiency_indicator_value;
+    ds.efficiency_indicator_aggregator =
+        r->second.efficiency_indicator_aggregator;
     ds.packet_delta_count = r->second.packet_delta_count;
     ds.flow_start_milliseconds = r->second.flow_start_milliseconds;
     ds.flow_end_milliseconds = r->second.flow_end_milliseconds;

--- a/externs/src/ipfix/ipfix.h
+++ b/externs/src/ipfix/ipfix.h
@@ -69,6 +69,7 @@ struct FlowRecordDataSet {
   uint16_t destination_transport_port;        // IANA IEID = 11
   uint32_t efficiency_indicator_id;           // IANA IEID = 5050
   uint64_t efficiency_indicator_value;        // IANA IEID = 5051
+  uint8_t efficiency_indicator_aggregator;    // IANA IEID = 5052
   uint64_t packet_delta_count;                // IANA IEID = 2
   uint64_t flow_start_milliseconds;           // IANA IEID = 152
   uint64_t flow_end_milliseconds;             // IANA IEID = 153
@@ -100,10 +101,10 @@ typedef unsigned char RawRecord[RAW_EXPORT_IPV6_HEADER_SIZE];
 // The packed attribute is set because the memcpy operation is performed on
 // instances of this type.
 struct RawRecordDataSet {
-  uint8_t ioam_report_flags;
-  uint8_t forwarding_status;
-  uint16_t section_exported_octets;
-  RawRecord ip_header_packet_section;
+  uint8_t ioam_report_flags;          // IANA IEID = 5053
+  uint8_t forwarding_status;          // IANA IEID = 89
+  uint16_t section_exported_octets;   // IANA IEID = 410
+  RawRecord ip_header_packet_section; // IANA IEID = 313
 } __attribute__((packed));
 
 // FlowRecordCache maps a flow key on the corresponding FlowRecord.

--- a/externs/src/ipfix/ipfix.h
+++ b/externs/src/ipfix/ipfix.h
@@ -85,6 +85,7 @@ struct FlowRecord {
   uint16_t destination_transport_port;
   uint32_t efficiency_indicator_id;
   uint64_t efficiency_indicator_value;
+  uint8_t efficiency_indicator_aggregator;
   uint64_t packet_delta_count;
   uint64_t flow_start_milliseconds;
   uint64_t flow_end_milliseconds;

--- a/externs/src/ipfix/ipfix.h
+++ b/externs/src/ipfix/ipfix.h
@@ -154,6 +154,12 @@ FlowRecordCache *GetFlowRecordCache(uint32_t indicator_id);
 // IPFIX_RAW_EXPORT_SAMPLE_RATE packets ago. Else it returns false.
 bool IsRawExportRequired(FlowRecordCache *cache, const bm::Data &flow_key);
 
+// Returns the aggregated efficiency indicator value.
+// In case an unsupported aggregator is given the current value is returned,
+// otherwise the current value is aggregated with the aggregate.
+uint64_t AggregateEfficiencyIndicatorValue(uint64_t current, uint32_t aggregate,
+                                           uint8_t aggregator);
+
 // Processes a given record by updating the cache entry in the cache with the
 // corresponding efficiency indicator id and matching flow key.
 // In case the cache does not contain an entry with the given flow key,


### PR DESCRIPTION
@refu7 please go ahead an review and test the changes.

As dicussed there is the need to distinct the data not only by indicator id (IOAM data param) but also by the indicator aggregator (IOAM aggregator).

The current implementation supports the aggregators (SUM=1), (MIN=2), (MAX=4).

I adjusted the composition of the cache index key which is a 32 bit value. Before it was only the 24 bit data param and now the 24 most siginficant bits are the data param and the 8 least siginificant bits are the aggregator. This ensures that values with different aggregators and data param are cached seperately.

Make sure to use this version (commit=bc9e78f77092b95dc62de966cb4e1a24a921063d) in the efficiency-indicator-p4 repository for testing.