### PR TITLE
Add export of IOAM Aggregation flags

### DIFF
--- a/externs/src/ipfix/export.cpp
+++ b/externs/src/ipfix/export.cpp
@@ -38,12 +38,16 @@ void ExportTemplates() {
       FieldSpecifier{.information_element_id = 5050, .field_length = 4},
       FieldSpecifier{.information_element_id = 5051, .field_length = 8},
       FieldSpecifier{.information_element_id = 5052, .field_length = 1},
+      FieldSpecifier{.information_element_id = 5053, .field_length = 8},
+      FieldSpecifier{.information_element_id = 5054, .field_length = 8},
+      FieldSpecifier{.information_element_id = 5055, .field_length = 8},
+      FieldSpecifier{.information_element_id = 5056, .field_length = 8},
       FieldSpecifier{.information_element_id = 2, .field_length = 8},
       FieldSpecifier{.information_element_id = 152, .field_length = 8},
       FieldSpecifier{.information_element_id = 153, .field_length = 8},
   };
   std::list<FieldSpecifier> raw_export_template_records = {
-      FieldSpecifier{.information_element_id = 5053, .field_length = 1},
+      FieldSpecifier{.information_element_id = 5060, .field_length = 1},
       FieldSpecifier{.information_element_id = 89, .field_length = 1},
       FieldSpecifier{.information_element_id = 410, .field_length = 2},
       FieldSpecifier{.information_element_id = 313,

--- a/externs/src/ipfix/export_utils.cpp
+++ b/externs/src/ipfix/export_utils.cpp
@@ -197,6 +197,10 @@ uint8_t *GetPayload(FlowRecordCache &records, size_t size) {
     ds.efficiency_indicator_value = r->second.efficiency_indicator_value;
     ds.efficiency_indicator_aggregator =
         r->second.efficiency_indicator_aggregator;
+    ds.packet_delta_count_flag_1 = r->second.packet_delta_count_flag_1;
+    ds.packet_delta_count_flag_2 = r->second.packet_delta_count_flag_2;
+    ds.packet_delta_count_flag_3 = r->second.packet_delta_count_flag_3;
+    ds.packet_delta_count_flag_4 = r->second.packet_delta_count_flag_4;
     ds.packet_delta_count = r->second.packet_delta_count;
     ds.flow_start_milliseconds = r->second.flow_start_milliseconds;
     ds.flow_end_milliseconds = r->second.flow_end_milliseconds;

--- a/externs/src/ipfix/hton.cpp
+++ b/externs/src/ipfix/hton.cpp
@@ -46,6 +46,10 @@ void hton(FlowRecordDataSet &record) {
   record.destination_transport_port = htons(record.destination_transport_port);
   record.efficiency_indicator_id = htonl(record.efficiency_indicator_id);
   record.efficiency_indicator_value = htonll(record.efficiency_indicator_value);
+  record.packet_delta_count_flag_1 = htonll(record.packet_delta_count_flag_1);
+  record.packet_delta_count_flag_2 = htonll(record.packet_delta_count_flag_2);
+  record.packet_delta_count_flag_3 = htonll(record.packet_delta_count_flag_3);
+  record.packet_delta_count_flag_4 = htonll(record.packet_delta_count_flag_4);
   record.packet_delta_count = htonll(record.packet_delta_count);
   record.flow_start_milliseconds = htonll(record.flow_start_milliseconds);
   record.flow_end_milliseconds = htonll(record.flow_end_milliseconds);

--- a/externs/src/ipfix/ipfix.h
+++ b/externs/src/ipfix/ipfix.h
@@ -70,6 +70,10 @@ struct FlowRecordDataSet {
   uint32_t efficiency_indicator_id;           // IANA IEID = 5050
   uint64_t efficiency_indicator_value;        // IANA IEID = 5051
   uint8_t efficiency_indicator_aggregator;    // IANA IEID = 5052
+  uint64_t packet_delta_count_flag_1;         // IANA IEID = 5053
+  uint64_t packet_delta_count_flag_2;         // IANA IEID = 5054
+  uint64_t packet_delta_count_flag_3;         // IANA IEID = 5055
+  uint64_t packet_delta_count_flag_4;         // IANA IEID = 5056
   uint64_t packet_delta_count;                // IANA IEID = 2
   uint64_t flow_start_milliseconds;           // IANA IEID = 152
   uint64_t flow_end_milliseconds;             // IANA IEID = 153
@@ -87,10 +91,15 @@ struct FlowRecord {
   uint32_t efficiency_indicator_id;
   uint64_t efficiency_indicator_value;
   uint8_t efficiency_indicator_aggregator;
+  uint64_t packet_delta_count_flag_1;
+  uint64_t packet_delta_count_flag_2;
+  uint64_t packet_delta_count_flag_3;
+  uint64_t packet_delta_count_flag_4;
   uint64_t packet_delta_count;
   uint64_t flow_start_milliseconds;
   uint64_t flow_end_milliseconds;
   uint64_t last_raw_export;
+  bool ignore_efficiency_data;
 };
 
 // Array data structure that holds IPv6 header raw data as so called raw
@@ -101,7 +110,7 @@ typedef unsigned char RawRecord[RAW_EXPORT_IPV6_HEADER_SIZE];
 // The packed attribute is set because the memcpy operation is performed on
 // instances of this type.
 struct RawRecordDataSet {
-  uint8_t ioam_report_flags;          // IANA IEID = 5053
+  uint8_t ioam_report_flags;          // IANA IEID = 5060
   uint8_t forwarding_status;          // IANA IEID = 89
   uint16_t section_exported_octets;   // IANA IEID = 410
   RawRecord ip_header_packet_section; // IANA IEID = 313
@@ -140,7 +149,9 @@ void InitFlowRecord(FlowRecord &dst_record, const bm::Data &flow_label_ipv6,
                     const bm::Data &source_transport_port,
                     const bm::Data &destination_transport_port,
                     const bm::Data &efficiency_indicator_id,
-                    const bm::Data &efficiency_indicator_value);
+                    const bm::Data &efficiency_indicator_value,
+                    const bm::Data &efficiency_indicator_aggregator,
+                    const bm::Data &efficiency_indicator_flags);
 
 // Returns a pointer to the FlowRecordCache holding entries for the given
 // indicator_id. In case there is no active cache for the given indicator_id in
@@ -210,14 +221,17 @@ void DeleteRawRecords();
 // and export process. This function is the entry point in the ipfix
 // implementation and starts all related background threads if not already
 // started.
-void ProcessPacketFlowData(const bm::Data &node_id, const bm::Data &flow_key,
-                           const bm::Data &flow_label_ipv6,
-                           const bm::Data &source_ipv6_address,
-                           const bm::Data &destination_ipv6_address,
-                           const bm::Data &source_transport_port,
-                           const bm::Data &destination_transport_port,
-                           const bm::Data &efficiency_indicator_id,
-                           const bm::Data &efficiency_indicator_value);
+void ProcessEfficiencyIndicatorMetadata(
+    const bm::Data &node_id, const bm::Data &flow_key,
+    const bm::Data &flow_label_ipv6, const bm::Data &source_ipv6_address,
+    const bm::Data &destination_ipv6_address,
+    const bm::Data &source_transport_port,
+    const bm::Data &destination_transport_port,
+    const bm::Data &efficiency_indicator_id,
+    const bm::Data &efficiency_indicator_value,
+    const bm::Data &efficiency_indicator_aggregator,
+    const bm::Data &efficiency_indicator_flags,
+    const bm::Data &raw_ipv6_header);
 
 // Function signatures in export.cpp
 


### PR DESCRIPTION
Hi @refu7 

As discussed yesterday I added the flag counters to the aggregated export.
There is now a counter for each flag which counts on how many packets of the flow the flag was set.
Additionally a total packet count which was present before.

Please review and adjust the configuration of the collector that it works with this new version.
Regarding the queries we will just include the flows where the error flags where 0.
On the dashboards we will add some visualizations to show how many and which errors occurred.